### PR TITLE
Restrict year picker to configured date bounds

### DIFF
--- a/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
+++ b/singledateandtimepicker/src/main/java/com/github/florent37/singledateandtimepicker/SingleDateAndTimePicker.java
@@ -599,14 +599,36 @@ public class SingleDateAndTimePicker extends LinearLayout {
     }
 
     private void setMinYear() {
+        if (!displayYears) {
+            return;
+        }
 
-        if (displayYears && this.minDate != null && this.maxDate != null) {
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTimeZone(dateHelper.getTimeZone());
+        final Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(dateHelper.getTimeZone());
+
+        Integer minYearValue = null;
+        Integer maxYearValue = null;
+
+        if (this.minDate != null) {
             calendar.setTime(this.minDate);
-            yearsPicker.setMinYear(calendar.get(Calendar.YEAR));
+            minYearValue = calendar.get(Calendar.YEAR);
+        }
+
+        if (this.maxDate != null) {
             calendar.setTime(this.maxDate);
-            yearsPicker.setMaxYear(calendar.get(Calendar.YEAR));
+            maxYearValue = calendar.get(Calendar.YEAR);
+        }
+
+        if (minYearValue != null && maxYearValue != null && minYearValue > maxYearValue) {
+            minYearValue = maxYearValue;
+        }
+
+        if (minYearValue != null) {
+            yearsPicker.setMinYear(minYearValue);
+        }
+
+        if (maxYearValue != null) {
+            yearsPicker.setMaxYear(maxYearValue);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the year wheel respects provided min and max dates even when only one bound is supplied
- prevent scrolling past the configured maximum year by always updating the picker limits

## Testing
- `./gradlew test` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fe9ffa7c8323b54492eaf10ddff2